### PR TITLE
Amended the Wordpress Nginx configuration to attempt to use the automatically generated robots.txt file

### DIFF
--- a/templates/default/nginx_vhost_wordpress.conf.erb
+++ b/templates/default/nginx_vhost_wordpress.conf.erb
@@ -28,7 +28,7 @@ server {
     }
 
     location = /robots.txt {
-        allow all;
+        try_files $uri $uri/ /index.php?$args;
         log_not_found off;
         access_log off;
     }


### PR DESCRIPTION
Amended the Wordpress Nginx configuration to attempt to use the automatically generated robots.txt file, if a physical one doesn't exist. This is perfect for multi-site solutions that use plugins, like Parasol.